### PR TITLE
Refresh machine docs with linked quickstarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,44 +2,48 @@
 
 _A practical, evolving field manual for our digital fabrication lab. Built to help people make more, better, and safer._
 
-- **Scope:** 3D printers (MakerBot Sketch, Sketch+; MakerBot Method X; LulzBot Mini 3) and **CNC** (Genmitsu Cubiko).
-- **Audience:** students, staff, and community members; new operators through advanced maintainers.
-- **Status:** initial scaffold · 2025-09-19. This repo is intentionally modular and versioned. Treat it like a handbook and a lab log.
+- **Scope:** 3D printers (MakerBot Sketch, Sketch+, Method X; LulzBot Mini 3) and **CNC** (Genmitsu Cubiko).
+- **Audience:** students, staff, and community members — from first-timers to battle-tested maintainers.
+- **Status:** initial scaffold · 2025-09-19. Treat it like a handbook and a lab log that never sleeps.
 
-## Repo Map
+## Why this repo exists
 
-```
-fab-machine-docs/
-  machines/
-    makerbot-sketch/
-    makerbot-sketch-plus/
-    makerbot-method-x/
-    lulzbot-mini-3/
-    genmitsu-cubiko/
-  templates/
-  docs/
-  .github/
-```
+We keep tripping over the same questions: _Which profile do I use?_ _Where do I log the weird noise?_ Rather than repeat tribal knowledge, this repo captures the intent behind every job. Every doc should teach you how to succeed today **and** how to leave breadcrumbs for the next operator.
 
-## How to Use
+> _The lab is a chorus; every operator should leave it singing a little more in tune._
 
-1. Start at your **machine folder** → read the `README.md` → follow the **SOP** and **Safety**.
-2. Complete the **Operator Checklist** and **Quiz** to earn your badge.
-3. When you learn something new, **submit a PR**—this is a living document.
+## Quick orientation
 
-## Contribution Rhythm
+- **Machines** — Start with your rig’s folder and read the local `README.md`:
+  - [MakerBot Sketch](machines/makerbot-sketch/)
+  - [MakerBot Sketch+](machines/makerbot-sketch-plus/)
+  - [MakerBot Method X](machines/makerbot-method-x/)
+  - [LulzBot Mini 3](machines/lulzbot-mini-3/)
+  - [Genmitsu Cubiko (CNC)](machines/genmitsu-cubiko/)
+- **Shared docs** — Lab-wide standards, pipelines, and training live in [`/docs`](docs/). Highlights:
+  - [Lab Safety](docs/lab-safety.md)
+  - [3D Printing Pipeline](docs/printing-pipeline.md) & [CNC Pipeline](docs/cnc-pipeline.md)
+  - [Onboarding](docs/onboarding.md) and [Training Pathways](docs/training-pathways.md)
+- **Templates** — Drop-in scaffolds for SOPs, job sheets, and forms live in [`/templates`](templates/).
+- **Personal rigs** — Ben’s side quests and retrofit notes are in [`/personal-machines`](personal-machines/).
 
-- Small fixes: open a PR with a clear diff and photos if relevant.
-- New procedures: start from `/templates/SOP-template.md`.
-- Incidents: record in the machine’s `/logs/incident-log.csv` within 24 hours and file an issue.
+## How to use these docs
 
-> _The lab is a chorus: each user leaves it singing more in tune than they found it._
+1. Start in your **machine folder** → read the local [`README`](machines/) → follow its linked **Quick Start**, **Safety**, and **SOP**.
+2. Grab the relevant **Operator Checklist**, templates, or slicer profiles directly from the folder paths linked in each doc.
+3. After every run, update the maintenance or incident logs so the next human sees the full story.
+4. Found a better trick? **Submit a PR** with context, photos, or data. This repo only stays alive if we feed it.
 
----
+## Contribution rhythm
+
+- **Small fixes** — Quick typo, new photo, or parameter tweak? Open a PR with a tight diff and before/after notes.
+- **New procedures** — Fork the [`SOP template`](templates/SOP-template.md) or other scaffolds and document the “why” alongside the “how”.
+- **Incidents** — Log the event in the machine’s [`incident log`](machines/) within 24 hours and open an issue so we can swarm it.
+
 ## Firmware policy
 
-All machines run **stock firmware** unless noted in their machine page. Personal machines include explicit firmware notes and links.
+All machines run **stock firmware** unless their machine page calls out a controlled deviation. Personal machines include explicit firmware notes and links; don’t freestyle without documenting the rollback path.
 
-## Personal machines
+---
 
-See `/personal-machines/` for Ben's machines and retrofit plans.
+Need something that isn’t here yet? Open an issue, drop your context, and let’s hack the gap together.

--- a/machines/genmitsu-cubiko/README.md
+++ b/machines/genmitsu-cubiko/README.md
@@ -2,11 +2,19 @@
 
 _Aim: reliable, repeatable results with clear guardrails._
 
-- Start with `quickstart.md` and `sop.md`.
-- Keep `logs/maintenance-log.csv` up to date.
-- Profiles live in `profiles/` and should be **versioned** and labeled by slicer.
+## Start here
+- [Quick Start](./quickstart.md) — practice run that covers CAM-to-machine basics.
+- [Safety](./safety.md) — chip containment, PPE, and emergency stops.
+- [SOP](./sop.md) — the authoritative preflight → run → cleanup sequence.
 
-## Notes
-- GRBL-based workflow. Keep tool database (`templates/cnc-tool-database.csv`) synced.
-- Always dry-run above stock and confirm safe Z.
-- Use `templates/cnc-job-sheet.md` for each job.
+## Keep the trail warm
+- [Maintenance log](./logs/maintenance-log.csv) — document tram checks, fixture changes, or firmware notes.
+- [Incident log](./logs/incident-log.csv) — capture tool breaks or near-misses within 24 hours.
+- [Profiles & CAM assets](./profiles/) — post processors, tool libraries, and sample jobs.
+- [Checklists](./checklists/) — setup and teardown aides.
+- [Training assets](./training/) — skill ladders, CAM exercises, and QR references.
+
+## Field notes
+- Workflow is GRBL-based; keep the tool database synced with [`templates/cnc-tool-database.csv`](../../templates/cnc-tool-database.csv).
+- Always dry-run above stock to verify safe Z and work offsets before cutting chips.
+- Use the [`cnc-job-sheet`](../../templates/cnc-job-sheet.md) for every job and store completed sheets per project policy.

--- a/machines/genmitsu-cubiko/quickstart.md
+++ b/machines/genmitsu-cubiko/quickstart.md
@@ -1,8 +1,9 @@
 # Quick Start — Genmitsu Cubiko (CNC)
 
-**Goal:** First successful job in ~15 minutes.
+**Goal:** Execute a safe, clean cut in ~15 minutes while validating work offsets and feeds.
 
-1. Read `safety.md` and know the E‑Stop.
-2. Use the provided **Sample Job** in `/profiles/sample`.
-3. Follow `sop.md` → Preflight, Operation, Postflight.
-4. Record your run in `/logs/maintenance-log.csv` if you changed anything.
+1. Read the [safety brief](./safety.md) and confirm chip containment and dust collection are ready.
+2. Load the **sample job** from [`profiles/sample`](./profiles/sample/) and verify CAM settings (units, origin, tools) match the machine.
+3. Walk through the [SOP](./sop.md): Preflight → Operation → Postflight — include an air-cut above stock.
+4. Document tool changes, tram adjustments, or fixture tweaks in the [maintenance log](./logs/maintenance-log.csv).
+5. Log broken tools, stock pull-outs, or near-misses in the [incident log](./logs/incident-log.csv) so we can adjust procedures.

--- a/machines/lulzbot-mini-3/README.md
+++ b/machines/lulzbot-mini-3/README.md
@@ -2,10 +2,19 @@
 
 _Aim: reliable, repeatable results with clear guardrails._
 
-- Start with `quickstart.md` and `sop.md`.
-- Keep `logs/maintenance-log.csv` up to date.
-- Profiles live in `profiles/` and should be **versioned** and labeled by slicer.
+## Start here
+- [Quick Start](./quickstart.md) — dial in your first print with Cura and lab checks.
+- [Safety](./safety.md) — hazards, hot surfaces, and emergency stops.
+- [SOP](./sop.md) — the definitive runbook from preflight to shutdown.
 
-## Notes
-- Use Cura (LulzBot Edition or Cura) profiles stored in `profiles/`.
-- Record Z-offset per build surface.
+## Keep the trail warm
+- [Maintenance log](./logs/maintenance-log.csv) — note nozzle wipes, offsets, or bed swaps.
+- [Incident log](./logs/incident-log.csv) — record jams or anomalies within 24 hours.
+- [Profiles](./profiles/) — Cura profiles; version them by material and layer height.
+- [Checklists](./checklists/) — training aides and certification forms.
+- [Training assets](./training/) — quizzes, demos, and QR codes.
+
+## Field notes
+- Use Cura (LulzBot Edition or vanilla Cura) profiles from the [profiles](./profiles/) folder; keep lab-specific adjustments documented.
+- Track Z-offset per build surface in the [calibration](./calibration.md) doc.
+- Update the [materials](./materials.md) list when adding filaments or changing temperature ranges.

--- a/machines/lulzbot-mini-3/quickstart.md
+++ b/machines/lulzbot-mini-3/quickstart.md
@@ -1,8 +1,9 @@
 # Quick Start — LulzBot Mini 3
 
-**Goal:** First successful job in ~15 minutes.
+**Goal:** Achieve a clean print in ~15 minutes while learning the Cura-driven workflow.
 
-1. Read `safety.md` and know the E‑Stop.
-2. Use the provided **Sample Job** in `/profiles/sample`.
-3. Follow `sop.md` → Preflight, Operation, Postflight.
-4. Record your run in `/logs/maintenance-log.csv` if you changed anything.
+1. Review the [safety brief](./safety.md) so you know the burn points and E-stop locations.
+2. Load the **sample job** from [`profiles/sample`](./profiles/sample/) using the Cura profile noted for this lab.
+3. Follow the [SOP](./sop.md) exactly: Preflight → Operation → Postflight.
+4. Record any offset tweaks, wiping station changes, or nozzle swaps in the [maintenance log](./logs/maintenance-log.csv).
+5. Capture jams, adhesion fails, or anything off-nominal in the [incident log](./logs/incident-log.csv) before the shift ends.

--- a/machines/makerbot-method-x/README.md
+++ b/machines/makerbot-method-x/README.md
@@ -2,10 +2,19 @@
 
 _Aim: reliable, repeatable results with clear guardrails._
 
-- Start with `quickstart.md` and `sop.md`.
-- Keep `logs/maintenance-log.csv` up to date.
-- Profiles live in `profiles/` and should be **versioned** and labeled by slicer.
+## Start here
+- [Quick Start](./quickstart.md) — get oriented and run a controlled first print.
+- [Safety](./safety.md) — ventilation, PPE, and emergency stops for this enclosed system.
+- [SOP](./sop.md) — canonical checklist from preflight through shutdown.
 
-## Notes
-- Enclosed printer; treat ABS/ASA jobs with ventilation protocols.
-- Note soluble supports if used; dispose per policy.
+## Keep the trail warm
+- [Maintenance log](./logs/maintenance-log.csv) — capture chamber temp tweaks, offsets, and consumables.
+- [Incident log](./logs/incident-log.csv) — log jams, purge issues, or enclosure alarms within 24 hours.
+- [Profiles](./profiles/) — Method X slicer profiles; version them by material + support strategy.
+- [Checklists](./checklists/) — training aides and run cards.
+- [Training assets](./training/) — quizzes, videos, and QR resources.
+
+## Field notes
+- Treat ABS/ASA jobs with proper ventilation and schedule them when the lab can handle fumes.
+- Document soluble support usage and disposal steps in the [materials](./materials.md) file.
+- Keep [calibration](./calibration.md) data current; the enclosed environment can drift with chamber heat.

--- a/machines/makerbot-method-x/quickstart.md
+++ b/machines/makerbot-method-x/quickstart.md
@@ -1,8 +1,9 @@
 # Quick Start — MakerBot Method X
 
-**Goal:** First successful job in ~15 minutes.
+**Goal:** Produce a clean, enclosed-chamber print in ~15 minutes while respecting fumes and supports.
 
-1. Read `safety.md` and know the E‑Stop.
-2. Use the provided **Sample Job** in `/profiles/sample`.
-3. Follow `sop.md` → Preflight, Operation, Postflight.
-4. Record your run in `/logs/maintenance-log.csv` if you changed anything.
+1. Study the [safety brief](./safety.md); confirm ventilation and purge paths are active.
+2. Load the **sample job** from [`profiles/sample`](./profiles/sample/) and verify the chamber + material settings match the cartridge installed.
+3. Execute the [SOP](./sop.md) in order: Preflight → Operation → Postflight — no skipping warmups.
+4. Log temperature offsets, purge strips, or material swaps in the [maintenance log](./logs/maintenance-log.csv).
+5. Capture jams, enclosure alarms, or anomalies in the [incident log](./logs/incident-log.csv) so we can troubleshoot fast.

--- a/machines/makerbot-sketch-plus/README.md
+++ b/machines/makerbot-sketch-plus/README.md
@@ -2,10 +2,18 @@
 
 _Aim: reliable, repeatable results with clear guardrails._
 
-- Start with `quickstart.md` and `sop.md`.
-- Keep `logs/maintenance-log.csv` up to date.
-- Profiles live in `profiles/` and should be **versioned** and labeled by slicer.
+## Start here
+- [Quick Start](./quickstart.md) — land a quality print fast while learning the flow.
+- [Safety](./safety.md) — hazards, ventilation cues, and the E-stop drill.
+- [SOP](./sop.md) — authoritative checklist for preflight → run → postflight.
 
-## Notes
-- Similar workflow to Sketch; keep profiles separate and versioned.
-- Record any differences in build volume or nozzle options here.
+## Keep the trail warm
+- [Maintenance log](./logs/maintenance-log.csv) — record tune-ups, offsets, or consumable swaps.
+- [Incident log](./logs/incident-log.csv) — log misfires or material issues inside 24 hours.
+- [Profiles](./profiles/) — slicer configs; tag versions by slicer + nozzle combo.
+- [Checklists](./checklists/) — laminated aides for students and mentors.
+- [Training assets](./training/) — quizzes, slides, and QR-ready references.
+
+## Field notes
+- Shares workflow DNA with the Sketch, but keep profiles separate to respect build volume differences.
+- Document nozzle swaps or alternate build surfaces directly in the [materials](./materials.md) and [calibration](./calibration.md) notes.

--- a/machines/makerbot-sketch-plus/quickstart.md
+++ b/machines/makerbot-sketch-plus/quickstart.md
@@ -1,8 +1,9 @@
 # Quick Start — MakerBot Sketch+
 
-**Goal:** First successful job in ~15 minutes.
+**Goal:** Ship a trustworthy print in ~15 minutes while learning the lab-specific quirks.
 
-1. Read `safety.md` and know the E‑Stop.
-2. Use the provided **Sample Job** in `/profiles/sample`.
-3. Follow `sop.md` → Preflight, Operation, Postflight.
-4. Record your run in `/logs/maintenance-log.csv` if you changed anything.
+1. Review the [safety brief](./safety.md) and confirm ventilation is on point for the material.
+2. Slice the **sample job** from [`profiles/sample`](./profiles/sample/) with the correct nozzle + slicer profile.
+3. March through the [SOP](./sop.md): Preflight → Operation → Postflight without skipping checkboxes.
+4. Log any offsets, swaps, or tweaks in the [maintenance log](./logs/maintenance-log.csv) before you walk away.
+5. If anything went sideways, drop a note in the [incident log](./logs/incident-log.csv) so the crew can debrief.

--- a/machines/makerbot-sketch/README.md
+++ b/machines/makerbot-sketch/README.md
@@ -2,10 +2,19 @@
 
 _Aim: reliable, repeatable results with clear guardrails._
 
-- Start with `quickstart.md` and `sop.md`.
-- Keep `logs/maintenance-log.csv` up to date.
-- Profiles live in `profiles/` and should be **versioned** and labeled by slicer.
+## Start here
+- [Quick Start](./quickstart.md) — get a successful print out in about 15 minutes.
+- [Safety](./safety.md) — hazards, PPE, and how to slam the E-stop without flinching.
+- [SOP](./sop.md) — the canonical preflight → run → postflight flow.
 
-## Notes
-- Uses cloud or desktop slicer per our environment.
-- Verify filament diameter and profile units (mm).
+## Keep the trail warm
+- [Maintenance log](./logs/maintenance-log.csv) — record tweaks, swaps, or weird noises.
+- [Incident log](./logs/incident-log.csv) — document anything sketchy within 24 hours.
+- [Profiles](./profiles/) — slicer configs; version them by slicer + material combo.
+- [Checklists](./checklists/) — printable aides for training or checkout.
+- [Training assets](./training/) — quizzes, slide decks, or QR codes.
+
+## Field notes
+- Runs MakerBot cloud or desktop slicers depending on the lab station; confirm before you slice.
+- Double-check filament diameter and units (mm) in any imported profile before pressing go.
+- Keep [materials](./materials.md) and [calibration](./calibration.md) docs updated as the machine drifts.

--- a/machines/makerbot-sketch/quickstart.md
+++ b/machines/makerbot-sketch/quickstart.md
@@ -1,8 +1,9 @@
 # Quick Start — MakerBot Sketch
 
-**Goal:** First successful job in ~15 minutes.
+**Goal:** Get your first clean print in ~15 minutes without sacrificing safety or the machine.
 
-1. Read `safety.md` and know the E‑Stop.
-2. Use the provided **Sample Job** in `/profiles/sample`.
-3. Follow `sop.md` → Preflight, Operation, Postflight.
-4. Record your run in `/logs/maintenance-log.csv` if you changed anything.
+1. Read the local [safety brief](./safety.md) and point out the E-stop to a buddy.
+2. Load the provided **sample job** from [`profiles/sample`](./profiles/sample/) and confirm the slicer matches the lab station.
+3. Follow the [SOP](./sop.md) step-by-step: Preflight → Operation → Postflight.
+4. If you touched hardware, swapped filament, or noticed a quirk, log it in the [maintenance log](./logs/maintenance-log.csv).
+5. Anything unexpected? Capture it in the [incident log](./logs/incident-log.csv) so the next crew can react fast.


### PR DESCRIPTION
## Summary
- rewrite the root README with clearer navigation, teaching-focused framing, and direct links to key folders
- restructure each machine README to surface quick-start, safety, sop, and logging resources with live links
- expand all machine quickstart guides with safety, profile, and logging links while aligning tone across the fleet

## Testing
- not run (documentation-only)


------
https://chatgpt.com/codex/tasks/task_e_68cd7dc05bf8832589a5d07c2f150264