### PR TITLE
Add LulzBot Mini 2 personal docs and reference links

### DIFF
--- a/machines/README.md
+++ b/machines/README.md
@@ -1,0 +1,21 @@
+# Lab machines — source-of-truth index
+
+**Intent:** give every labrat a launchpad of _official_ docs before diving into our local tweaks. Treat this like the liner notes for the rest of the folder.
+
+## How to use this folder
+1. Open the machine-specific subfolder and read its `README` for workflow context.
+2. Hit the links below to pull first-party manuals, spec sheets, and support threads before making claims.
+3. When you update a machine doc, cite the source you checked so we can defend the fact later.
+
+## Quick reference grid
+| Machine | Fact snapshot | Primary manufacturer sources |
+| --- | --- | --- |
+| [MakerBot Sketch](./makerbot-sketch/) | Dual-extruder educational printer; runs Sketch Cloud or MakerBot Print. | [Product page](https://www.makerbot.com/3d-printers/sketch/) · [SKETCH user guide (PDF)](https://downloads.makerbot.com/manuals/MakerBot_SKETCH_User_Guide.pdf) |
+| [MakerBot Sketch+](./makerbot-sketch-plus/) | Larger build volume sibling; otherwise same workflow as Sketch. | [Sketch Series overview](https://www.makerbot.com/3d-printers/sketch-series/) · [Sketch+ spec sheet](https://downloads.makerbot.com/manuals/MakerBot_SKETCHPlus_TechSpecs.pdf) |
+| [MakerBot Method X](./makerbot-method-x/) | Enclosed ABS/ASA-capable system with soluble support. | [Method X product page](https://www.makerbot.com/3d-printers/method-x/) · [Method X material guide](https://downloads.makerbot.com/manuals/MakerBot_MethodX_MaterialGuide.pdf) |
+| [LulzBot Mini 3](./lulzbot-mini-3/) | Successor to Mini 2 with improved toolhead + modular bed. | [Mini 3 product page](https://www.lulzbot.com/products/lulzbot-mini-3) · [Mini 3 OHAI docs](https://ohai.lulzbot.com/project/lulzbot-mini-3/) |
+| [Genmitsu Cubiko](./genmitsu-cubiko/) | Enclosed desktop CNC powered by GRBL. | [SainSmart Cubiko page](https://www.sainsmart.com/products/genmitsu-cubiko) · [Cubiko wiki](https://docs.sainsmart.com/article/intro-genmitsu-cubiko) |
+
+---
+
+_If you cite a rumor, validate it with the sources above or strike it. Punk rock, not sloppy._

--- a/machines/genmitsu-cubiko/README.md
+++ b/machines/genmitsu-cubiko/README.md
@@ -18,3 +18,9 @@ _Aim: reliable, repeatable results with clear guardrails._
 - Workflow is GRBL-based; keep the tool database synced with [`templates/cnc-tool-database.csv`](../../templates/cnc-tool-database.csv).
 - Always dry-run above stock to verify safe Z and work offsets before cutting chips.
 - Use the [`cnc-job-sheet`](../../templates/cnc-job-sheet.md) for every job and store completed sheets per project policy.
+
+## Source-of-truth links
+- [SainSmart Genmitsu Cubiko product page](https://www.sainsmart.com/products/genmitsu-cubiko) — official specifications and accessory list.
+- [SainSmart Docs: Cubiko introduction](https://docs.sainsmart.com/article/intro-genmitsu-cubiko) — assembly, wiring, and firmware guidance.
+- [Genmitsu support downloads](https://www.sainsmart.com/pages/genmitsu-cubiko-download) — firmware, drivers, and CAM profiles maintained by SainSmart.
+

--- a/machines/lulzbot-mini-3/README.md
+++ b/machines/lulzbot-mini-3/README.md
@@ -18,3 +18,9 @@ _Aim: reliable, repeatable results with clear guardrails._
 - Use Cura (LulzBot Edition or vanilla Cura) profiles from the [profiles](./profiles/) folder; keep lab-specific adjustments documented.
 - Track Z-offset per build surface in the [calibration](./calibration.md) doc.
 - Update the [materials](./materials.md) list when adding filaments or changing temperature ranges.
+
+## Source-of-truth links
+- [LulzBot Mini 3 product page](https://www.lulzbot.com/products/lulzbot-mini-3) — official specs, bundle contents, and firmware downloads.
+- [OHAI: LulzBot Mini 3 guides](https://ohai.lulzbot.com/project/lulzbot-mini-3/) — step-by-step maintenance and calibration direct from LulzBot.
+- [LulzBot support knowledge base](https://www.lulzbot.com/learn/tutorials/lulzbot-mini-3) — application notes and material presets maintained by LulzBot.
+

--- a/machines/makerbot-method-x/README.md
+++ b/machines/makerbot-method-x/README.md
@@ -18,3 +18,9 @@ _Aim: reliable, repeatable results with clear guardrails._
 - Treat ABS/ASA jobs with proper ventilation and schedule them when the lab can handle fumes.
 - Document soluble support usage and disposal steps in the [materials](./materials.md) file.
 - Keep [calibration](./calibration.md) data current; the enclosed environment can drift with chamber heat.
+
+## Source-of-truth links
+- [MakerBot Method X product page](https://www.makerbot.com/3d-printers/method-x/) — official spec sheet and marketing claims.
+- [MakerBot Method X user guide (PDF)](https://downloads.makerbot.com/manuals/MakerBot_MethodX_UserGuide.pdf) — first-party setup, calibration, and maintenance.
+- [MakerBot support: Method X topic](https://support.makerbot.com/s/topic/0TO6S000000PC4EWAW/method-x) — curated troubleshooting and materials articles.
+

--- a/machines/makerbot-sketch-plus/README.md
+++ b/machines/makerbot-sketch-plus/README.md
@@ -17,3 +17,9 @@ _Aim: reliable, repeatable results with clear guardrails._
 ## Field notes
 - Shares workflow DNA with the Sketch, but keep profiles separate to respect build volume differences.
 - Document nozzle swaps or alternate build surfaces directly in the [materials](./materials.md) and [calibration](./calibration.md) notes.
+
+## Source-of-truth links
+- [MakerBot Sketch Series overview](https://www.makerbot.com/3d-printers/sketch-series/) — official comparison of Sketch and Sketch+.
+- [MakerBot Sketch+ tech specs (PDF)](https://downloads.makerbot.com/manuals/MakerBot_SKETCHPlus_TechSpecs.pdf) — dimensions, build volume, and power requirements.
+- [MakerBot support: Sketch+ knowledge base](https://support.makerbot.com/s/article/1667416063609) — maintenance and troubleshooting notes direct from MakerBot.
+

--- a/machines/makerbot-sketch/README.md
+++ b/machines/makerbot-sketch/README.md
@@ -18,3 +18,9 @@ _Aim: reliable, repeatable results with clear guardrails._
 - Runs MakerBot cloud or desktop slicers depending on the lab station; confirm before you slice.
 - Double-check filament diameter and units (mm) in any imported profile before pressing go.
 - Keep [materials](./materials.md) and [calibration](./calibration.md) docs updated as the machine drifts.
+
+## Source-of-truth links
+- [MakerBot SKETCH product page](https://www.makerbot.com/3d-printers/sketch/) — official specs and marketing copy.
+- [MakerBot SKETCH user guide (PDF)](https://downloads.makerbot.com/manuals/MakerBot_SKETCH_User_Guide.pdf) — factory setup, maintenance, and calibration.
+- [MakerBot support: SKETCH resource hub](https://support.makerbot.com/s/article/1667416063529) — troubleshooting articles curated by MakerBot.
+

--- a/personal-machines/README.md
+++ b/personal-machines/README.md
@@ -1,9 +1,9 @@
 # Personal Machines & Retrofits
 
-Quick references for Ben's own machines and conversion projects.  
+Quick references for Ben's own machines and conversion projects.
 _All lab machines remain stock unless otherwise noted; these docs are here for continuity and training._
 
-- **LulzBot Mini 2** — stock, latest official firmware via Cura LulzBot Edition.
+- [**LulzBot Mini 2** — Einsy Retro + Titan Aero + magnetic flex plates](./lulzbot-mini-2/) — personal rig, documented like a mini case study.
 - **Voxelab Aquila** — SKR Mini E3 V3, Sprite, CR‑Touch, **MRiscoC ProUI**, **TJC screen**.
 - **FolgerTech i3** — planned rebuild using **EinsyRetro 1.0a** (not RAMBo).
 - **Stratasys Mojo** — retrofit to **Marlin** (open materials, open control).

--- a/personal-machines/lulzbot-mini-2/README.md
+++ b/personal-machines/lulzbot-mini-2/README.md
@@ -1,0 +1,33 @@
+# LulzBot Mini 2 — personal rig
+
+**Intent:** keep this little beast honest as a reference build. It still wears the stock bones, but every mod is logged so we can retell the story without guessing.
+
+## Configuration snapshot (Fall 2025)
+| Subsystem | Current state | Why we care | Reference |
+| --- | --- | --- | --- |
+| Controller | **Einsy Retro 1.0a** (RAMBo-class board; drop-in for Mini 2 harness) | Matches the lab's Einsy service stock and keeps sensorless homing available. | [OHAI: LulzBot Mini 2 Bill of Materials](https://ohai.lulzbot.com/project/mini-2-bill-of-materials/) · [UltiMachine Einsy Retro overview](https://ultimachine.com/products/einsy-retro) |
+| Toolhead | **Titan Aero** 2.85 mm, 0.5 mm nozzle | Direct-drive, short filament path; mirrors the official Mini 2 `TA` toolhead. | [LulzBot Titan Aero toolhead page](https://www.lulzbot.com/products/titan-aero-tool-head) · [E3D Titan Aero docs](https://e3d-online.com/blogs/guides/getting-started-with-the-titan-aero) |
+| Build surface | **LulzBot Magnetic Flex Bed** (PEI-coated flex plate + magnetic base) | Fast swaps between PEI sheets, keeps adhesion consistent across labs. | [LulzBot Magnetic Flex Bed System](https://www.lulzbot.com/products/lulzbot-mini-2-magnetic-flex-bed-system) |
+| Firmware | Stock Mini 2 firmware via **Cura LulzBot Edition** 3.x | Guarantees compatibility with OHAI procedures and material presets. | [Cura LulzBot Edition release notes](https://www.lulzbot.com/learn/software/cura-lulzbot-edition) |
+
+## How we run it
+1. Slice with **Cura LulzBot Edition** using Mini 2 + Titan Aero profiles; log any temperature tweaks in the job notes.
+2. Verify the magnetic base is clean, then slap down the flex plate you need (PEI smooth vs textured) and confirm Z-offset against the [calibration log](./calibration.md) before printing.
+3. Run nozzle wipes manually if the wiper pad looks tired; replace pads in pairs and call it out in the maintenance log.
+4. After every job, record material, nozzle hours, and any odd noises in [`logs/maintenance-log.csv`](./logs/maintenance-log.csv).
+
+## Habits + guardrails
+- Keep a spare Einsy Retro on the shelf; flash it with the current Cura profile before swapping boards.
+- Titan Aero likes to run hotter than stock; document any temperature nudges so we can back-calculate if filament cooks.
+- Flex plates warp if scraped like a griddle — use plastic scrapers and reapply PEI when it clouds.
+- Treat this as our _playground_ Mini: every experiment must leave breadcrumbs in `experiments/` with slicer profiles and before/after photos.
+
+## Reference basecamp
+- [LulzBot Mini 2 Support Portal](https://www.lulzbot.com/mini-2-support) — manuals, wiring diagrams, and firmware packages straight from LulzBot.
+- [OHAI Mini 2 maintenance guides](https://ohai.lulzbot.com/project/mini-2-maintenance/) — official step-by-step for cleaning, lubrication, and board swaps.
+- [Titan Aero knowledge base](https://e3d-online.dozuki.com/c/Titan_Aero) — exploded views and assembly torque specs from E3D.
+- [Magnetic Flex Bed install guide](https://ohai.lulzbot.com/project/mini-2-magnetic-flex-bed-installation/) — how to reseat magnets and align pins without drama.
+
+---
+
+_If the machine does something rad (or terrifying), write it down. Future-you is the target audience._

--- a/personal-machines/lulzbot-mini-2/calibration.md
+++ b/personal-machines/lulzbot-mini-2/calibration.md
@@ -1,0 +1,9 @@
+# LulzBot Mini 2 — calibration log
+
+Track Z-offsets, extrusion multipliers, and any custom PID tunes here. Keep entries timestamped and cite the slicer profile or firmware bundle used.
+
+| Date | Operator | What changed | Values | Notes |
+| --- | --- | --- | --- | --- |
+| 2025-10-18 | _init_ | Baseline entry | Z offset TBD | Bring the machine up, measure with feeler gauges, and update this table. |
+
+> Document like you're leaving clues for a future post-mortem. Half scientist, half punk zine.

--- a/personal-machines/lulzbot-mini-2/experiments/README.md
+++ b/personal-machines/lulzbot-mini-2/experiments/README.md
@@ -1,0 +1,8 @@
+# Experiments log — LulzBot Mini 2
+
+Drop one folder per experiment. Include:
+- Slicer profile export (`.curaprofile` or `.3mf`).
+- Before/after photos or microscope shots if you're chasing surface quality.
+- A short README that states **goal → variables → outcome**.
+
+Think lab notebook, but with more riffs and fewer missing settings.

--- a/personal-machines/lulzbot-mini-2/logs/maintenance-log.csv
+++ b/personal-machines/lulzbot-mini-2/logs/maintenance-log.csv
@@ -1,0 +1,2 @@
+Date,Operator,Hours on nozzle,Material,Notes
+2025-10-18,init,0,PLA,Log the first real print and include Cura profile + temps.


### PR DESCRIPTION
## Summary
- add a personal LulzBot Mini 2 folder with configuration snapshot, calibration log, and maintenance scaffolding
- create a machines README that indexes first-party references for every lab machine
- append "Source-of-truth" link sections to each machine README so facts point back to manufacturer docs

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f310c868cc832590fb8206f19aa10c