### PR TITLE
Add logging review playbook and monthly audit template

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ We keep tripping over the same questions: _Which profile do I use?_ _Where do I 
 
 1. Start in your **machine folder** → read the local [`README`](machines/) → follow its linked **Quick Start**, **Safety**, and **SOP**.
 2. Grab the relevant **Operator Checklist**, templates, or slicer profiles directly from the folder paths linked in each doc.
-3. After every run, update the maintenance or incident logs so the next human sees the full story.
+3. After every run, update the maintenance or incident logs so the next human sees the full story, then hit the [Machine Logging Playbook](docs/logging-playbook.md) to stay synced on review cadence.
 4. Found a better trick? **Submit a PR** with context, photos, or data. This repo only stays alive if we feed it.
 
 ## Contribution rhythm

--- a/docs/logging-playbook.md
+++ b/docs/logging-playbook.md
@@ -1,0 +1,50 @@
+# Machine Logging Playbook
+
+_Keep the logs loud, honest, and useful. If we don't write it down, it didn't happen._
+
+## Why this exists
+Our lab's heartbeat lives in two CSVs:
+- [`logs/maintenance-log.csv`](../logs/maintenance-log.csv) — running tally of every tune-up, swap, and calibration tweak.
+- [`logs/incident-log.csv`](../logs/incident-log.csv) — when a print fails spectacularly or a spindle screams, this is where the truth goes.
+
+Consistent review turns raw data into signal so we can retire flaky components before they bite us twice.
+
+## Routine review workflow
+1. **Pull the latest main branch** so you aren't reading stale data.
+2. **Open `logs/maintenance-log.csv`.** Sort by `machine` then `date`.
+   - Look for overdue preventative tasks (`status` != `closed`).
+   - Flag repeated notes for the same subsystem (e.g., "Z wobble" twice in a month).
+   - Cross-check that any parts ordered in prior entries now show an install date.
+3. **Scan `logs/incident-log.csv`.** Sort by `severity` high→low, then `date`.
+   - Confirm each incident has a `resolution_owner` and `follow_up` status.
+   - Add links to supporting evidence (photos, gcode, tickets) if missing.
+   - If an incident required decommissioning, ensure the machine folder README reflects it.
+4. **Capture deltas.** Drop bullets in the audit template (see [`templates/monthly-log-audit-checklist.csv`](../templates/monthly-log-audit-checklist.csv)) noting:
+   - Machines needing action this month.
+   - Parts to order, training gaps, and open root-cause hunts.
+5. **Publish the notes.** Commit the filled audit template back to `logs/audits/YYYY-MM/` with a short PR explaining themes.
+
+## Audit cadence
+| Cadence | Who | Scope | Output |
+| --- | --- | --- | --- |
+| **Weekly spot-check** | Shift lead (rotating) | New entries only | Slack ping or lab notebook note; update owners if missing |
+| **Monthly deep audit** | Maintenance captain + apprentice | Full maintenance + incident logs | Completed audit template + issue/PR backlog |
+| **Quarterly retro** | Lab manager + safety officer | Trends across 3 months | Retro doc with theme clusters + policy tweaks |
+
+Miss a beat? Catch up within 48 hours and log why so we can fix the blockage.
+
+## Escalation pathways
+- **Recurring faults (same subsystem ≥3 times in 60 days):**
+  1. Tag the machine steward and lab manager in the incident entry.
+  2. Open a GitHub issue labeled `recurring-fault` with links to the relevant log rows.
+  3. Draft a containment plan within 72 hours (temporary downtime, restricted operators, etc.).
+- **Safety-critical incidents (injury, near-miss, fire):**
+  1. Halt the machine immediately and mark it "LOCKED OUT" on-site.
+  2. Notify campus safety per lab SOP and file the formal report.
+  3. Update `logs/incident-log.csv` with full details + `severity=critical`.
+  4. Schedule an emergency review within 24 hours and document outcomes in `/docs/safety-retros/`.
+- **Data quality rot (missing fields, duplicate entries):**
+  - Fix the rows, note the correction in the audit template, and coach the operator who missed the mark.
+
+## Keep it punk, not chaotic
+The goal is radical transparency. We document to keep each other safe, to ship better prints, and to build a trail we can trust when the dean walks in. When in doubt, log it and let the data tell the story.

--- a/machines/README.md
+++ b/machines/README.md
@@ -6,6 +6,7 @@
 1. Open the machine-specific subfolder and read its `README` for workflow context.
 2. Hit the links below to pull first-party manuals, spec sheets, and support threads before making claims.
 3. When you update a machine doc, cite the source you checked so we can defend the fact later.
+4. Close the loop by logging work in `logs/maintenance-log.csv` or `logs/incident-log.csv`, then review the [Machine Logging Playbook](../docs/logging-playbook.md) so trends don't slip past us.
 
 ## Quick reference grid
 | Machine | Fact snapshot | Primary manufacturer sources |

--- a/templates/monthly-log-audit-checklist.csv
+++ b/templates/monthly-log-audit-checklist.csv
@@ -1,0 +1,2 @@
+"Month","Reviewer(s)","Date completed","Machines needing action","Parts to order","Training gaps","Follow-up issues opened","Notes / links"
+"2025-__","Name1, Name2","YYYY-MM-DD","MakerBot Sketch: extruder heat creep","ABS, HEPA filters","Need refresher on lockout/tagout","#123 recurring-fault","Link to PRs, photos, drive folder"


### PR DESCRIPTION
## Summary
- add a machine logging playbook that defines review workflow, audit cadence, and escalation paths
- link the new playbook from the main README and the machines index so operators see the review loop
- provide a monthly log audit checklist template for capturing review outcomes

## Testing
- not run (docs update)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69153d4260488325b036cacc99416c75)